### PR TITLE
Changed config before the migration step

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,17 +36,17 @@ You can install the package via composer:
 composer require rawilk/laravel-settings
 ```
 
+You can publish the config file with:
+
+```bash
+php artisan vendor:publish --tag="settings-config"
+```
+
 You can publish and run the migrations with:
 
 ```bash
 php artisan vendor:publish --tag="settings-migrations"
 php artisan migrate
-```
-
-You can publish the config file with:
-
-```bash
-php artisan vendor:publish --tag="settings-config"
 ```
 
 You can view the default configuration here: https://github.com/rawilk/laravel-settings/blob/main/config/breadcrumbs.php


### PR DESCRIPTION
Change the order in which a developer would publish the config file to be before performing the migration. This is also recommended since the user has the ability to change the settings table name which is used in the migration file and is referenced in the settings config file.

1️⃣ Is this something that is wanted/needed? Did you create an issue / discussion about it first?
Not necessarily, just a QOL update to the way a new developer may be reading/initializing the package for the first time.

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
No.

3️⃣ Does it include tests, if possible? (Not a deal-breaker, just a nice-to-have)
No.

4️⃣ Please include a thorough description of the improvement and reasons why it's useful.
If a developer would like to change any config options, more specifically the settings table name, it would be nice to have that option before performing the migration. This removed the secondary step of migrating, then wanting to change the table name and having to revert and migrate again.

5️⃣ Thanks for contributing! 🙌
🥂 