### PR TITLE
Allow migration to be reversed

### DIFF
--- a/database/migrations/create_settings_table.php.stub
+++ b/database/migrations/create_settings_table.php.stub
@@ -14,4 +14,14 @@ return new class extends Migration
             $table->longText('value')->nullable();
         });
     }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists(config('settings.table'));
+    }
 };


### PR DESCRIPTION
Add the down function to the migration file to allow it to be reversed without causing any issues when rolling back the migrations