### PR TITLE
Add team support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,10 +29,8 @@
         "laravel/pint": "^1.2",
         "mockery/mockery": "^1.4.2",
         "orchestra/testbench": "^6.5|^7.0|^8.0",
-        "pestphp/pest": "^1.22",
-        "pestphp/pest-plugin-laravel": "^1.3",
-        "pestphp/pest-plugin-parallel": "^1.0|^1.2",
-        "phpunit/phpunit": "^9.4",
+        "pestphp/pest": "^1.22|^2.10",
+        "pestphp/pest-plugin-laravel": "^1.3|^2.2",
         "spatie/laravel-ray": "^1.0|^1.31"
     },
     "autoload": {

--- a/config/settings.php
+++ b/config/settings.php
@@ -79,4 +79,35 @@ return [
             'model' => \Rawilk\Settings\Models\Setting::class,
         ],
     ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Teams
+    |--------------------------------------------------------------------------
+    |
+    | When set to true the package implements teams using the `team_foreign_key`.
+    |
+    | If you want the migrations to register the `team_foreign_key`, you must
+    | set this to true before running the migration.
+    |
+    | If you already ran the migrations, then you must make a new migration to
+    | add the `team_foreign_key` column to the settings table, and update the
+    | unique constraint on the table. See the `add_settings_team_field` migration
+    | for how to do this.
+    |
+    */
+    'teams' => false,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Team Foreign Key
+    |--------------------------------------------------------------------------
+    |
+    | When teams is set to true, our database/eloquent drivers will use this
+    | column as a team foreign key to scope queries to.
+    |
+    | The team id will also be included in a cache key when caching is enabled.
+    |
+    */
+    'team_foreign_key' => 'team_id',
 ];

--- a/database/migrations/add_settings_team_field.php.stub
+++ b/database/migrations/add_settings_team_field.php.stub
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! config('settings.teams')) {
+            return;
+        }
+
+        Schema::table(config('settings.table'), function (Blueprint $table) {
+            $table->unsignedBigInteger(config('settings.team_foreign_key'))->nullable()->after('id');
+            $table->index(config('settings.team_foreign_key'), 'settings_team_id_index');
+
+            $table->dropUnique('settings_key_unique');
+
+            $table->unique([
+                'key',
+                config('settings.team_foreign_key'),
+            ]);
+        });
+    }
+};

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,14 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit backupGlobals="false"
-         backupStaticAttributes="false"
-         bootstrap="vendor/autoload.php"
-         colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnFailure="false"
-         verbose="true"
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd"
+    bootstrap="vendor/autoload.php"
+    colors="true"
 >
     <testsuites>
         <testsuite name="Laravel Settings Test Suite">

--- a/src/Contracts/Driver.php
+++ b/src/Contracts/Driver.php
@@ -6,11 +6,11 @@ namespace Rawilk\Settings\Contracts;
 
 interface Driver
 {
-    public function forget($key);
+    public function forget($key, $teamId = null);
 
-    public function get(string $key, $default = null);
+    public function get(string $key, $default = null, $teamId = null);
 
-    public function has($key): bool;
+    public function has($key, $teamId = null): bool;
 
-    public function set(string $key, $value = null);
+    public function set(string $key, $value = null, $teamId = null);
 }

--- a/src/Contracts/Setting.php
+++ b/src/Contracts/Setting.php
@@ -6,11 +6,11 @@ namespace Rawilk\Settings\Contracts;
 
 interface Setting
 {
-    public static function getValue(string $key, $default = null);
+    public static function getValue(string $key, $default = null, $teamId = null);
 
-    public static function has($key): bool;
+    public static function has($key, $teamId = null): bool;
 
-    public static function removeSetting($key);
+    public static function removeSetting($key, $teamId = null);
 
-    public static function set(string $key, $value = null);
+    public static function set(string $key, $value = null, $teamId = null);
 }

--- a/src/Drivers/DatabaseDriver.php
+++ b/src/Drivers/DatabaseDriver.php
@@ -7,41 +7,65 @@ namespace Rawilk\Settings\Drivers;
 use Illuminate\Database\Connection;
 use Illuminate\Database\Query\Builder;
 use Rawilk\Settings\Contracts\Driver;
-use Throwable;
 
 class DatabaseDriver implements Driver
 {
-    public function __construct(protected Connection $connection, protected string $table)
-    {
+    public function __construct(
+        protected Connection $connection,
+        protected string $table,
+        protected ?string $teamForeignKey = null,
+    ) {
     }
 
-    public function forget($key): void
+    public function forget($key, $teamId = null): void
     {
-        $this->table()->where('key', $key)->delete();
+        $this->db()
+            ->where('key', $key)
+            ->when(
+                $teamId !== false,
+                fn (Builder $query) => $query->where("{$this->table}.{$this->teamForeignKey}", $teamId)
+            )
+            ->delete();
     }
 
-    public function get(string $key, $default = null)
+    public function get(string $key, $default = null, $teamId = null)
     {
-        $value = $this->table()->where('key', $key)->value('value');
+        $value = $this->db()
+            ->where('key', $key)
+            ->when(
+                $teamId !== false,
+                fn (Builder $query) => $query->where("{$this->table}.{$this->teamForeignKey}", $teamId)
+            )
+            ->value('value');
 
         return $value ?? $default;
     }
 
-    public function has($key): bool
+    public function has($key, $teamId = null): bool
     {
-        return $this->table()->where('key', $key)->exists();
+        return $this->db()
+            ->where('key', $key)
+            ->when(
+                $teamId !== false,
+                fn (Builder $query) => $query->where("{$this->table}.{$this->teamForeignKey}", $teamId)
+            )
+            ->exists();
     }
 
-    public function set(string $key, $value = null): void
+    public function set(string $key, $value = null, $teamId = null): void
     {
-        try {
-            $this->table()->insert(compact('key', 'value'));
-        } catch (Throwable) {
-            $this->table()->where('key', $key)->update(compact('value'));
+        $data = [
+            'key' => $key,
+        ];
+
+        if ($teamId !== false) {
+            $data[$this->teamForeignKey] = $teamId;
         }
+
+        $this->db()->updateOrInsert($data, compact('value'));
     }
 
-    protected function table(): Builder
+    protected function db(): Builder
     {
         return $this->connection->table($this->table);
     }

--- a/src/Drivers/EloquentDriver.php
+++ b/src/Drivers/EloquentDriver.php
@@ -13,23 +13,23 @@ class EloquentDriver implements Driver
     {
     }
 
-    public function forget($key): void
+    public function forget($key, $teamId = null): void
     {
-        $this->model::removeSetting($key);
+        $this->model::removeSetting($key, $teamId);
     }
 
-    public function get(string $key, $default = null)
+    public function get(string $key, $default = null, $teamId = null)
     {
-        return $this->model::getValue($key, $default);
+        return $this->model::getValue($key, $default, $teamId);
     }
 
-    public function has($key): bool
+    public function has($key, $teamId = null): bool
     {
-        return $this->model::has($key);
+        return $this->model::has($key, $teamId);
     }
 
-    public function set(string $key, $value = null): void
+    public function set(string $key, $value = null, $teamId = null): void
     {
-        $this->model::set($key, $value);
+        $this->model::set($key, $value, $teamId);
     }
 }

--- a/src/Drivers/Factory.php
+++ b/src/Drivers/Factory.php
@@ -36,14 +36,17 @@ class Factory
     protected function createDatabaseDriver(array $config): DatabaseDriver
     {
         return new DatabaseDriver(
-            $this->app['db']->connection(Arr::get($config, 'connection')),
-            $this->app['config']['settings.table']
+            connection: $this->app['db']->connection(Arr::get($config, 'connection')),
+            table: $this->app['config']['settings.table'],
+            teamForeignKey: $this->app['config']['settings.team_foreign_key'] ?? null,
         );
     }
 
     protected function createEloquentDriver(): EloquentDriver
     {
-        return new EloquentDriver(app(SettingContract::class));
+        return new EloquentDriver(
+            model: app(SettingContract::class),
+        );
     }
 
     protected function getDefaultDriver(): string

--- a/src/Facades/Settings.php
+++ b/src/Facades/Settings.php
@@ -21,6 +21,11 @@ use Illuminate\Support\Facades\Facade;
  * @method static self temporarilyDisableCache()
  * @method static self disableEncryption()
  * @method static self enableEncryption()
+ * @method static null|mixed getTeamId()
+ * @method static self setTeamId(mixed $id)
+ * @method static self enableTeams()
+ * @method static self disableTeams()
+ * @method static bool teamsAreEnabled()
  */
 class Settings extends Facade
 {

--- a/src/Models/Setting.php
+++ b/src/Models/Setting.php
@@ -4,41 +4,78 @@ declare(strict_types=1);
 
 namespace Rawilk\Settings\Models;
 
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Rawilk\Settings\Contracts\Setting as SettingContract;
 
 class Setting extends Model implements SettingContract
 {
+    protected ?string $teamForeignKey = null;
+
     public function __construct(array $attributes = [])
     {
         parent::__construct($attributes);
 
         $this->setTable(config('settings.table'));
+        $this->teamForeignKey = config('settings.team_foreign_key');
     }
 
     protected $guarded = ['id'];
 
     public $timestamps = false;
 
-    public static function getValue(string $key, $default = null)
+    public static function getValue(string $key, $default = null, $teamId = null)
     {
-        $value = self::where('key', $key)->value('value');
+        $value = static::query()
+            ->where('key', $key)
+            ->when(
+                $teamId !== false,
+                fn (Builder $query) => $query->where(
+                    static::make()->getTable() . '.' . config('settings.team_foreign_key'),
+                    $teamId,
+                ),
+            )
+            ->value('value');
 
         return $value ?? $default;
     }
 
-    public static function has($key): bool
+    public static function has($key, $teamId = null): bool
     {
-        return self::where('key', $key)->exists();
+        return static::query()
+            ->where('key', $key)
+            ->when(
+                $teamId !== false,
+                fn (Builder $query) => $query->where(
+                    static::make()->getTable() . '.' . config('settings.team_foreign_key'),
+                    $teamId,
+                ),
+            )
+            ->exists();
     }
 
-    public static function removeSetting($key): void
+    public static function removeSetting($key, $teamId = null): void
     {
-        self::where('key', $key)->delete();
+        static::query()
+            ->where('key', $key)
+            ->when(
+                $teamId !== false,
+                fn (Builder $query) => $query->where(
+                    static::make()->getTable() . '.' . config('settings.team_foreign_key'),
+                    $teamId,
+                ),
+            )
+            ->delete();
     }
 
-    public static function set(string $key, $value = null)
+    public static function set(string $key, $value = null, $teamId = null)
     {
-        return self::updateOrCreate(compact('key'), compact('value'));
+        $data = ['key' => $key];
+
+        if ($teamId !== false) {
+            $data[config('settings.team_foreign_key')] = $teamId;
+        }
+
+        return static::updateOrCreate($data, compact('value'));
     }
 }

--- a/tests/Feature/Drivers/DatabaseDriverTest.php
+++ b/tests/Feature/Drivers/DatabaseDriverTest.php
@@ -2,56 +2,156 @@
 
 declare(strict_types=1);
 
-use Illuminate\Support\Facades\DB;
 use Rawilk\Settings\Drivers\DatabaseDriver;
 
+/**
+ * Note: Setting `false` as the team id in some calls is essentially like setting it to `false` in the config file.
+ */
 beforeEach(function () {
-    $this->driver = new DatabaseDriver(app('db')->connection(), 'settings');
-    $this->db = DB::table('settings');
+    config([
+        'settings.driver' => 'database',
+        'settings.teams' => true,
+        'settings.team_foreign_key' => 'team_id',
+    ]);
+
+    $this->driver = new DatabaseDriver(
+        connection: app('db')->connection(),
+        table: 'settings',
+        teamForeignKey: 'team_id',
+    );
+
+    migrateTeams();
+    setDatabaseDriverConnection();
 });
 
 it('creates new entries', function () {
-    $this->driver->set('foo', 'bar');
+    $this->driver->set('foo', 'bar', false);
 
-    expect($this->db->count())->toBe(1)
-        ->and($this->db->where('key', 'foo')->value('value'))->toBe('bar');
+    $this->assertDatabaseCount('settings', 1);
+
+    $this->assertDatabaseHas('settings', [
+        'key' => 'foo',
+        'value' => 'bar',
+        'team_id' => null,
+    ]);
+});
+
+it('creates new entries for teams', function () {
+    $this->driver->set('foo', 'bar', 1);
+
+    $this->assertDatabaseCount('settings', 1);
+
+    $this->assertDatabaseHas('settings', [
+        'key' => 'foo',
+        'value' => 'bar',
+        'team_id' => 1,
+    ]);
 });
 
 it('updates existing values', function () {
-    $this->driver->set('foo', 'bar');
+    $this->driver->set('foo', 'bar', false);
 
-    expect($this->db->where('key', 'foo')->value('value'))->toBe('bar');
+    $this->assertDatabaseHas('settings', [
+        'key' => 'foo',
+        'value' => 'bar',
+        'team_id' => null,
+    ]);
 
-    $this->driver->set('foo', 'updated value');
+    $this->driver->set('foo', 'updated value', false);
 
-    expect($this->db->count())->toBe(1)
-        ->and($this->db->where('key', 'foo')->value('value'))->toBe('updated value');
+    $this->assertDatabaseCount('settings', 1);
+
+    $this->assertDatabaseHas('settings', [
+        'key' => 'foo',
+        'value' => 'updated value',
+        'team_id' => null,
+    ]);
+});
+
+it('updates team values', function () {
+    $this->driver->set('foo', 'no team value', null);
+    $this->driver->set('foo', 'team value', 1);
+
+    $this->assertDatabaseCount('settings', 2);
+
+    $this->driver->set('foo', 'updated team value', 1);
+
+    $this->assertDatabaseCount('settings', 2);
+
+    $this->assertDatabaseHas('settings', [
+        'key' => 'foo',
+        'value' => 'no team value',
+        'team_id' => null,
+    ]);
+
+    $this->assertDatabaseHas('settings', [
+        'key' => 'foo',
+        'value' => 'updated team value',
+        'team_id' => 1,
+    ]);
 });
 
 it('checks if a setting is persisted', function () {
-    expect($this->driver->has('foo'))->toBeFalse();
+    expect($this->driver->has('foo', false))->toBeFalse();
 
-    $this->driver->set('foo', 'bar');
+    $this->driver->set('foo', 'bar', false);
 
-    expect($this->driver->has('foo'))->toBeTrue();
+    expect($this->driver->has('foo', false))->toBeTrue();
+});
+
+it('checks if a team setting is persisted', function () {
+    $this->driver->set('foo', 'no team value', null);
+    expect($this->driver->has('foo', 1))->toBeFalse();
+
+    $this->driver->set('foo', 'team value', 1);
+    expect($this->driver->has('foo', 1))->toBeTrue();
 });
 
 it('gets a persisted setting value', function () {
-    $this->driver->set('foo', 'some value');
+    $this->driver->set('foo', 'some value', false);
 
-    expect($this->driver->get('foo'))->toBe('some value');
+    expect($this->driver->get(key: 'foo', teamId: false))->toBe('some value');
 });
 
 it('returns a default value for settings that are not persisted', function () {
-    expect($this->driver->get('foo', 'my default value'))->toBe('my default value');
+    expect($this->driver->get(key: 'foo', default: 'my default value', teamId: false))->toBe('my default value');
+});
+
+it('gets a persisted team value', function () {
+    $this->driver->set('foo', 'no team value', null);
+    $this->driver->set('foo', 'team value', 1);
+
+    expect($this->driver->get(key: 'foo', teamId: 1))->toBe('team value');
+});
+
+it('gets a default value for a team', function () {
+    $this->driver->set('foo', 'no team value', null);
+
+    expect($this->driver->get(key: 'foo', default: 'my default', teamId: 1))->toBe('my default');
 });
 
 it('removes persisted settings', function () {
-    $this->driver->set('foo', 'bar');
+    $this->driver->set('foo', 'bar', false);
 
-    expect($this->driver->has('foo'))->toBeTrue();
+    expect($this->driver->has('foo', false))->toBeTrue();
 
-    $this->driver->forget('foo');
+    $this->driver->forget('foo', false);
 
-    expect($this->driver->has('foo'))->toBeFalse();
+    expect($this->driver->has('foo', false))->toBeFalse();
+});
+
+it('removes persisted team values', function () {
+    $this->driver->set('foo', 'team 1 value', 1);
+    $this->driver->set('foo', 'team 2 value', 2);
+
+    $this->assertDatabaseCount('settings', 2);
+
+    $this->driver->forget('foo', 1);
+
+    $this->assertDatabaseCount('settings', 1);
+
+    $this->assertDatabaseMissing('settings', [
+        'key' => 'foo',
+        'team_id' => 1,
+    ]);
 });

--- a/tests/Feature/Drivers/EloquentDriverTest.php
+++ b/tests/Feature/Drivers/EloquentDriverTest.php
@@ -5,53 +5,147 @@ declare(strict_types=1);
 use Rawilk\Settings\Drivers\EloquentDriver;
 use Rawilk\Settings\Models\Setting;
 
+/**
+ * Note: Setting `false` as the team id in some calls is essentially like setting it to `false` in the config file.
+ */
 beforeEach(function () {
+    config([
+        'settings.driver' => 'eloquent',
+        'settings.teams' => true,
+        'settings.team_foreign_key' => 'team_id',
+    ]);
+
     $this->driver = new EloquentDriver(app(Setting::class));
     $this->model = app(Setting::class);
+
+    migrateTeams();
 });
 
 it('creates new entries', function () {
-    $this->driver->set('foo', 'bar');
+    $this->driver->set('foo', 'bar', false);
 
-    expect($this->model::all())->count()->toBe(1)
-        ->and($this->model::first()->value)->toBe('bar');
+    $this->assertDatabaseCount($this->model, 1);
+
+    $this->assertDatabaseHas($this->model, [
+        'key' => 'foo',
+        'value' => 'bar',
+        'team_id' => null,
+    ]);
+});
+
+it('creates new entries for teams', function () {
+    $this->driver->set('foo', 'bar', 1);
+
+    $this->assertDatabaseCount($this->model, 1);
+
+    $this->assertDatabaseHas($this->model, [
+        'key' => 'foo',
+        'value' => 'bar',
+        'team_id' => 1,
+    ]);
 });
 
 it('updates existing entries', function () {
-    $this->driver->set('foo', 'bar');
+    $this->driver->set('foo', 'bar', false);
 
-    expect($this->model::first()->value)->toBe('bar');
+    $setting = $this->model::first();
 
-    $this->driver->set('foo', 'updated value');
+    expect($setting->value)->toBe('bar')
+        ->and($setting->team_id)->toBeNull();
 
-    expect($this->model::count())->toBe(1)
-        ->and($this->model::first()->value)->toBe('updated value');
+    $this->driver->set('foo', 'updated value', false);
+
+    $this->assertDatabaseCount($this->model, 1);
+
+    $updatedSetting = $this->model::first();
+
+    expect($updatedSetting->value)->toBe('updated value')
+        ->and($updatedSetting->team_id)->toBeNull();
+});
+
+it('updates team values', function () {
+    $this->driver->set('foo', 'no team value', null);
+    $this->driver->set('foo', 'team value', 1);
+
+    $this->assertDatabaseCount($this->model, 2);
+
+    $this->driver->set('foo', 'updated team value', 1);
+
+    $this->assertDatabaseCount($this->model, 2);
+
+    $this->assertDatabaseHas($this->model, [
+        'key' => 'foo',
+        'value' => 'no team value',
+        'team_id' => null,
+    ]);
+
+    $this->assertDatabaseHas($this->model, [
+        'key' => 'foo',
+        'value' => 'updated team value',
+        'team_id' => 1,
+    ]);
 });
 
 it('checks if a setting is persisted', function () {
-    expect($this->driver->has('foo'))->toBeFalse();
+    expect($this->driver->has('foo', false))->toBeFalse();
 
-    $this->driver->set('foo', 'bar');
+    $this->driver->set('foo', 'bar', false);
 
-    expect($this->driver->has('foo'))->toBeTrue();
+    expect($this->driver->has('foo', false))->toBeTrue();
+});
+
+it('checks if a team setting is persisted', function () {
+    $this->driver->set('foo', 'no team value', null);
+    expect($this->driver->has('foo', 1))->toBeFalse();
+
+    $this->driver->set('foo', 'team value', 1);
+    expect($this->driver->has('foo', 1))->toBeTrue();
 });
 
 it('gets a persisted setting value', function () {
-    $this->driver->set('foo', 'bar');
+    $this->driver->set('foo', 'bar', false);
 
-    expect($this->driver->get('foo'))->toBe('bar');
+    expect($this->driver->get(key: 'foo', teamId: false))->toBe('bar');
 });
 
 it('returns a default value for settings that are not persisted', function () {
-    expect($this->driver->get('foo', 'my default value'))->toBe('my default value');
+    expect($this->driver->get(key: 'foo', default: 'my default value', teamId: false))->toBe('my default value');
+});
+
+it('gets a persisted team value', function () {
+    $this->driver->set('foo', 'no team value', null);
+    $this->driver->set('foo', 'team value', 1);
+
+    expect($this->driver->get(key: 'foo', teamId: 1))->toBe('team value');
+});
+
+it('gets a default value for a team', function () {
+    $this->driver->set('foo', 'no team value', null);
+
+    expect($this->driver->get(key: 'foo', default: 'my default', teamId: 1))->toBe('my default');
 });
 
 it('removes persisted settings', function () {
     $this->driver->set('foo', 'bar');
+    expect($this->driver->has('foo', false))->toBeTrue();
 
-    expect($this->driver->has('foo'))->toBeTrue();
+    $this->driver->forget('foo', false);
 
-    $this->driver->forget('foo');
+    expect($this->driver->has('foo', false))->toBeFalse();
+});
 
-    expect($this->driver->has('foo'))->toBeFalse();
+it('removes persisted team values', function () {
+    $this->driver->set('foo', 'team 1 value', 1);
+    $this->driver->set('foo', 'team 2 value', 2);
+
+    $this->assertDatabaseCount('settings', 2);
+
+    $this->driver->forget('foo', 1);
+
+    $this->assertDatabaseCount('settings', 1);
+
+    $this->assertDatabaseMissing('settings', [
+        'key' => 'foo',
+        'team_id' => 1,
+    ]);
 });

--- a/tests/Feature/HasSettingsTest.php
+++ b/tests/Feature/HasSettingsTest.php
@@ -9,8 +9,7 @@ use Rawilk\Settings\Tests\Support\Models\CustomUser;
 use Rawilk\Settings\Tests\Support\Models\User;
 
 beforeEach(function () {
-    $migration = include __DIR__ . '/../Support/database/migrations/create_test_tables.php';
-    $migration->up();
+    migrateTestTables();
 
     User::factory(2)->create();
 });

--- a/tests/Feature/SettingsTest.php
+++ b/tests/Feature/SettingsTest.php
@@ -14,15 +14,7 @@ beforeEach(function () {
         'settings.encryption' => false,
     ]);
 
-    // The Database driver doesn't seem to be using the same Sqlite connection the tests are using, so
-    // we'll force it to here. This should fix issues with the settings table not existing when the
-    // driver queries it.
-    $driver = Settings::getDriver();
-    $reflection = new ReflectionClass($driver);
-
-    $property = $reflection->getProperty('connection');
-    $property->setAccessible(true);
-    $property->setValue($driver, DB::connection());
+    setDatabaseDriverConnection();
 });
 
 it('can determine if a setting has been persisted', function () {

--- a/tests/Feature/TeamsTest.php
+++ b/tests/Feature/TeamsTest.php
@@ -1,0 +1,165 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\DB;
+use Rawilk\Settings\Facades\Settings as SettingsFacade;
+use Rawilk\Settings\Tests\Support\Models\Team;
+
+beforeEach(function () {
+    config([
+        'settings.driver' => 'database',
+        'settings.table' => 'settings',
+        'settings.cache' => false,
+        'settings.cache_key_prefix' => 'settings.',
+        'settings.encryption' => false,
+        'settings.teams' => true,
+        'settings.team_foreign_key' => 'team_id',
+    ]);
+
+    migrateTestTables();
+    migrateTeams();
+
+    setDatabaseDriverConnection();
+
+    Team::factory()->create();
+});
+
+test('teams can be enabled and disabled', function () {
+    // Should be enabled with the config value set to true
+    expect(SettingsFacade::teamsAreEnabled())->toBeTrue();
+
+    SettingsFacade::disableTeams();
+    expect(SettingsFacade::teamsAreEnabled())->toBeFalse();
+
+    SettingsFacade::enableTeams();
+    expect(SettingsFacade::teamsAreEnabled())->toBeTrue();
+});
+
+test('team id can be set', function () {
+    expect(SettingsFacade::getTeamId())->toBeNull();
+
+    SettingsFacade::setTeamId(1);
+
+    expect(SettingsFacade::getTeamId())->toBe(1);
+});
+
+it('sets a team id when saving', function () {
+    $team = Team::first();
+    SettingsFacade::setTeamId($team);
+
+    SettingsFacade::set('foo', 'bar');
+
+    $setting = DB::table('settings')->first();
+
+    expect($setting->team_id)->toBe($team->id);
+});
+
+it('updates team settings', function () {
+    $team = Team::first();
+    SettingsFacade::setTeamId($team);
+
+    SettingsFacade::set('foo', 'bar');
+    SettingsFacade::set('foo', 'updated');
+
+    $this->assertDatabaseCount('settings', 1);
+
+    $setting = DB::table('settings')->first();
+    $value = unserialize($setting->value);
+
+    expect($setting)->team_id->toBe($team->id)
+        ->and($value)->toBe('updated');
+});
+
+test('two teams can have the same setting', function () {
+    $team1 = Team::first();
+    $team2 = Team::factory()->create();
+
+    SettingsFacade::setTeamId($team1);
+    SettingsFacade::set('foo', 'team 1 value');
+
+    SettingsFacade::setTeamId($team2);
+    SettingsFacade::set('foo', 'team 2 value');
+
+    $this->assertDatabaseCount('settings', 2);
+
+    $setting1 = DB::table('settings')->where('team_id', $team1->id)->first();
+    $setting2 = DB::table('settings')->where('team_id', $team2->id)->first();
+
+    expect($setting1->team_id)->toBe($team1->id)
+        ->and(unserialize($setting1->value))->toBe('team 1 value')
+        ->and($setting2->team_id)->toBe($team2->id)
+        ->and(unserialize($setting2->value))->toBe('team 2 value')
+        ->and($setting1->key)->toBe($setting2->key);
+});
+
+it('checks if a team has a setting', function () {
+    SettingsFacade::set('foo', 'null team');
+    expect(SettingsFacade::has('foo'))->toBeTrue();
+
+    $team = Team::first();
+
+    SettingsFacade::setTeamId($team);
+    expect(SettingsFacade::has('foo'))->toBeFalse();
+
+    SettingsFacade::set('foo', 'team value');
+    expect(SettingsFacade::has('foo'))->toBeTrue();
+});
+
+it('gets a team setting value', function () {
+    $team = Team::first();
+    $team2 = Team::factory()->create();
+
+    // Also verify that no team id can be used
+    SettingsFacade::setTeamId(null);
+    SettingsFacade::set('foo', 'no team value');
+    expect(SettingsFacade::get('foo'))->toBe('no team value');
+
+    SettingsFacade::setTeamId($team);
+    SettingsFacade::set('foo', 'team value');
+    expect(SettingsFacade::get('foo'))->toBe('team value');
+
+    SettingsFacade::setTeamId($team2);
+    SettingsFacade::set('foo', 'team 2 value');
+    expect(SettingsFacade::get('foo'))->toBe('team 2 value');
+});
+
+it('forgets the settings for a team', function () {
+    $team = Team::first();
+
+    SettingsFacade::set('foo', 'no team value');
+
+    SettingsFacade::setTeamId($team);
+    SettingsFacade::set('foo', 'team value');
+
+    $this->assertDatabaseCount('settings', 2);
+
+    SettingsFacade::forget('foo');
+
+    $this->assertDatabaseCount('settings', 1);
+    $this->assertDatabaseMissing('settings', [
+        'team_id' => $team->id,
+    ]);
+    $this->assertDatabaseHas('settings', [
+        'team_id' => null,
+    ]);
+});
+
+test('the cache is scoped for teams', function () {
+    $team = Team::first();
+    $team2 = Team::factory()->create();
+
+    SettingsFacade::setTeamId($team);
+    SettingsFacade::set('foo', 'team 1 value');
+
+    SettingsFacade::setTeamId($team2);
+    SettingsFacade::set('foo', 'team 2 value');
+
+    SettingsFacade::enableCache();
+
+    expect(SettingsFacade::get('foo'))->toBe('team 2 value');
+
+    SettingsFacade::setTeamId($team);
+
+    expect(SettingsFacade::get('foo'))->toBe('team 1 value');
+});

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,5 +1,7 @@
 <?php
 
+use Illuminate\Support\Facades\DB;
+use Rawilk\Settings\Facades\Settings;
 use Rawilk\Settings\Tests\TestCase;
 
 uses(TestCase::class)->in(__DIR__);
@@ -21,4 +23,31 @@ if (! function_exists('fake') && class_exists(\Faker\Factory::class)) {
 
         return app()->make($abstract);
     }
+}
+
+/**
+ * The Database driver doesn't seem to be using the same Sqlite connection
+ * the tests are using, so we'll force it to here. This should fix issues
+ * with the settings table not existing when the driver queries it.
+ */
+function setDatabaseDriverConnection(): void
+{
+    $driver = Settings::getDriver();
+    $reflection = new ReflectionClass($driver);
+
+    $property = $reflection->getProperty('connection');
+    $property->setAccessible(true);
+    $property->setValue($driver, DB::connection());
+}
+
+function migrateTestTables(): void
+{
+    $migration = include __DIR__ . '/Support/database/migrations/create_test_tables.php';
+    $migration->up();
+}
+
+function migrateTeams(): void
+{
+    $migration = include __DIR__ . '/../database/migrations/add_settings_team_field.php.stub';
+    $migration->up();
 }

--- a/tests/Support/Drivers/CustomDriver.php
+++ b/tests/Support/Drivers/CustomDriver.php
@@ -6,24 +6,24 @@ namespace Rawilk\Settings\Tests\Support\Drivers;
 
 use Rawilk\Settings\Contracts\Driver;
 
-class CustomDriver implements Driver
+final class CustomDriver implements Driver
 {
-    public function forget($key): void
+    public function forget($key, $teamId = null): void
     {
         //
     }
 
-    public function get(string $key, $default = null)
+    public function get(string $key, $default = null, $teamId = null)
     {
         return $default;
     }
 
-    public function has($key): bool
+    public function has($key, $teamId = null): bool
     {
         return true;
     }
 
-    public function set(string $key, $value = null): void
+    public function set(string $key, $value = null, $teamId = null): void
     {
         //
     }

--- a/tests/Support/Models/Company.php
+++ b/tests/Support/Models/Company.php
@@ -9,7 +9,7 @@ use Illuminate\Database\Eloquent\Model;
 use Rawilk\Settings\Models\HasSettings;
 use Rawilk\Settings\Tests\Support\database\factories\CompanyFactory;
 
-class Company extends Model
+final class Company extends Model
 {
     use HasFactory;
     use HasSettings;

--- a/tests/Support/Models/CustomUser.php
+++ b/tests/Support/Models/CustomUser.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Rawilk\Settings\Tests\Support\Models;
 
-class CustomUser extends User
+final class CustomUser extends User
 {
     protected $table = 'users';
 

--- a/tests/Support/Models/Team.php
+++ b/tests/Support/Models/Team.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rawilk\Settings\Tests\Support\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Rawilk\Settings\Tests\Support\database\factories\TeamFactory;
+
+final class Team extends Model
+{
+    use HasFactory;
+
+    protected static function newFactory(): TeamFactory
+    {
+        return new TeamFactory;
+    }
+}

--- a/tests/Support/database/factories/TeamFactory.php
+++ b/tests/Support/database/factories/TeamFactory.php
@@ -5,19 +5,19 @@ declare(strict_types=1);
 namespace Rawilk\Settings\Tests\Support\database\factories;
 
 use Illuminate\Database\Eloquent\Factories\Factory;
-use Rawilk\Settings\Tests\Support\Models\Company;
+use Rawilk\Settings\Tests\Support\Models\Team;
 
 /**
- * @extends Factory<\Rawilk\Settings\Tests\Support\Models\Company>
+ * @extends Factory<\Rawilk\Settings\Tests\Support\Models\Team>
  */
-final class CompanyFactory extends Factory
+final class TeamFactory extends Factory
 {
-    protected $model = Company::class;
+    protected $model = Team::class;
 
     public function definition(): array
     {
         return [
-            'name' => fake()->company(),
+            'name' => fake()->name(),
         ];
     }
 }

--- a/tests/Support/database/migrations/create_test_tables.php
+++ b/tests/Support/database/migrations/create_test_tables.php
@@ -21,5 +21,11 @@ return new class extends Migration
             $table->string('name');
             $table->timestamps();
         });
+
+        Schema::create('teams', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->timestamps();
+        });
     }
 };

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -18,7 +18,13 @@ class TestCase extends Orchestra
 
     public function getEnvironmentSetUp($app): void
     {
-        $migration = include __DIR__ . '/../database/migrations/create_settings_table.php.stub';
-        $migration->up();
+        $migrations = [
+            'create_settings_table.php.stub',
+        ];
+
+        foreach ($migrations as $migrationName) {
+            $migration = include __DIR__ . '/../database/migrations/' . $migrationName;
+            $migration->up();
+        }
     }
 }


### PR DESCRIPTION
PR adds support for teams/multi-tenancy by adding a `team_id` (customizable) to the settings table. The Database and Eloquent drivers will support this when it is enabled in the config. This allows you to use the same settings key for different teams/tenants. 

This could be achieved already by setting a "team_id" in the context object for each setting call, however that would become tedious to do. Now the "team_id" can just be set once either in a service provider or in a middleware by calling the `setTeamId()` method on the `Settings` facade.

There are some breaking changes introduced with this PR, however I will address those in an upgrade guide and a new major version.
