### PR TITLE
Add custom value serializer support

### DIFF
--- a/config/settings.php
+++ b/config/settings.php
@@ -148,4 +148,19 @@ return [
     |
     */
     'key_generator' => \Rawilk\Settings\Support\KeyGenerators\Md5KeyGenerator::class,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Value Serializer
+    |--------------------------------------------------------------------------
+    |
+    | By default, we use php's serialize() and unserialize() functions to
+    | prepare the setting values for storage. You may use the `JsonValueSerializer`
+    | instead if you want to store the values as json instead.
+    |
+    | Any custom value serializer you use must implement the
+    | \Rawilk\Settings\Contracts\ValueSerializer interface.
+    |
+    */
+    'value_serializer' => \Rawilk\Settings\Support\ValueSerializers\ValueSerializer::class,
 ];

--- a/src/Contracts/ValueSerializer.php
+++ b/src/Contracts/ValueSerializer.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rawilk\Settings\Contracts;
+
+interface ValueSerializer
+{
+    public function serialize($value): string;
+
+    public function unserialize(string $serialized): mixed;
+}

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -11,8 +11,8 @@ use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Macroable;
 use Rawilk\Settings\Contracts\Driver;
 use Rawilk\Settings\Contracts\KeyGenerator;
+use Rawilk\Settings\Contracts\ValueSerializer;
 use Rawilk\Settings\Support\Context;
-use Rawilk\Settings\Support\ValueSerializer;
 
 class Settings
 {
@@ -23,8 +23,6 @@ class Settings
     protected ?Context $context = null;
 
     protected ?Encrypter $encrypter = null;
-
-    protected ValueSerializer $valueSerializer;
 
     protected bool $cacheEnabled = false;
 
@@ -47,8 +45,8 @@ class Settings
     public function __construct(
         protected Driver $driver,
         protected KeyGenerator $keyGenerator,
+        protected ValueSerializer $valueSerializer,
     ) {
-        $this->valueSerializer = new ValueSerializer;
     }
 
     // mainly for testing purposes

--- a/src/SettingsServiceProvider.php
+++ b/src/SettingsServiceProvider.php
@@ -8,6 +8,7 @@ use Rawilk\Settings\Contracts\Setting as SettingContract;
 use Rawilk\Settings\Drivers\Factory;
 use Rawilk\Settings\Support\ContextSerializers\ContextSerializer;
 use Rawilk\Settings\Support\KeyGenerators\Md5KeyGenerator;
+use Rawilk\Settings\Support\ValueSerializers\ValueSerializer;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
 
@@ -61,14 +62,15 @@ class SettingsServiceProvider extends PackageServiceProvider
         );
 
         $this->app->singleton(Settings::class, function ($app) {
-            $keyGenerator = $this->app->make($app['config']['settings.key_generator'] ?? Md5KeyGenerator::class);
+            $keyGenerator = $app->make($app['config']['settings.key_generator'] ?? Md5KeyGenerator::class);
             $keyGenerator->setContextSerializer(
-                $this->app->make($app['config']['settings.context_serializer'] ?? ContextSerializer::class)
+                $app->make($app['config']['settings.context_serializer'] ?? ContextSerializer::class)
             );
 
             $settings = new Settings(
-                $app['SettingsFactory']->driver(),
-                $keyGenerator,
+                driver: $app['SettingsFactory']->driver(),
+                keyGenerator: $keyGenerator,
+                valueSerializer: $app->make($app['config']['settings.value_serializer'] ?? ValueSerializer::class),
             );
 
             $settings->useCacheKeyPrefix($app['config']['settings.cache_key_prefix'] ?? '');

--- a/src/Support/ValueSerializers/JsonValueSerializer.php
+++ b/src/Support/ValueSerializers/JsonValueSerializer.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rawilk\Settings\Support\ValueSerializers;
+
+use Rawilk\Settings\Contracts\ValueSerializer as ValueSerializerContract;
+
+class JsonValueSerializer implements ValueSerializerContract
+{
+    public function serialize($value): string
+    {
+        return json_encode($value, JSON_THROW_ON_ERROR);
+    }
+
+    public function unserialize(string $serialized): mixed
+    {
+        return json_decode($serialized, true, 512, JSON_THROW_ON_ERROR);
+    }
+}

--- a/src/Support/ValueSerializers/ValueSerializer.php
+++ b/src/Support/ValueSerializers/ValueSerializer.php
@@ -2,9 +2,11 @@
 
 declare(strict_types=1);
 
-namespace Rawilk\Settings\Support;
+namespace Rawilk\Settings\Support\ValueSerializers;
 
-class ValueSerializer
+use Rawilk\Settings\Contracts\ValueSerializer as ValueSerializerContract;
+
+class ValueSerializer implements ValueSerializerContract
 {
     public function serialize($value): string
     {

--- a/tests/Feature/SettingsTest.php
+++ b/tests/Feature/SettingsTest.php
@@ -130,6 +130,22 @@ it('can evaluate stored boolean settings', function () {
         ->and(SettingsFacade::isFalse('app.debug'))->toBeFalse();
 });
 
+it('can evaluate boolean stored settings using the json value serializer', function () {
+    $settings = settings();
+    (fn () => $this->valueSerializer = new JsonValueSerializer)->call($settings);
+
+    $settings->set('app.debug', '1');
+    expect($settings->isTrue('app.debug'))->toBeTrue();
+
+    $settings->set('app.debug', '0');
+    expect($settings->isTrue('app.debug'))->toBeFalse()
+        ->and($settings->isFalse('app.debug'))->toBeTrue();
+
+    $settings->set('app.debug', true);
+    expect($settings->isTrue('app.debug'))->toBeTrue()
+        ->and($settings->isFalse('app.debug'))->toBeFalse();
+});
+
 it('can cache values on retrieval', function () {
     enableSettingsCache();
 

--- a/tests/Unit/ValueSerializers/JsonValueSerializerTest.php
+++ b/tests/Unit/ValueSerializers/JsonValueSerializerTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+use Rawilk\Settings\Support\ValueSerializers\JsonValueSerializer;
+
+beforeEach(function () {
+    $this->serializer = new JsonValueSerializer;
+});
+
+it('serializes values as json', function (mixed $value, string $expected) {
+    expect($this->serializer->serialize($value))->toBe($expected);
+})->with([
+    [1, '1'],
+    ['1', '"1"'],
+    [true, 'true'],
+    [false, 'false'],
+    [0, '0'],
+    [null, 'null'],
+    [1.1, '1.1'],
+    [['array' => 'array'], '{"array":"array"}'],
+    [[1, '2', 3], '[1,"2",3]'],
+    [(object) ['a' => 'b'], '{"a":"b"}'],
+]);
+
+it('unserializes json values', function (string $value, mixed $expected) {
+    expect($this->serializer->unserialize($value))->toBe($expected);
+})->with([
+    ['1', 1],
+    ['"1"', '1'],
+    ['true', true],
+    ['false', false],
+    ['0', 0],
+    ['null', null],
+    ['1.1', 1.1],
+    ['{"array":"array"}', ['array' => 'array']],
+    ['{"a":"b"}', ['a' => 'b']],
+]);

--- a/tests/Unit/ValueSerializers/ValueSerializerTest.php
+++ b/tests/Unit/ValueSerializers/ValueSerializerTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-use Rawilk\Settings\Support\ValueSerializer;
+use Rawilk\Settings\Support\ValueSerializers\ValueSerializer;
 
 it('serializes values', function (mixed $value) {
     $serializer = new ValueSerializer;


### PR DESCRIPTION
PR adds support for using custom value serializers. Also adds an alternative `JsonValueSerializer` to `json_encode` and `json_decode` values in storage instead of using php's `serialize`  and `unserialize` functions.
