### PR TITLE
Fetch/Flush All Settings

### DIFF
--- a/src/Contracts/Driver.php
+++ b/src/Contracts/Driver.php
@@ -4,11 +4,15 @@ declare(strict_types=1);
 
 namespace Rawilk\Settings\Contracts;
 
+use Illuminate\Contracts\Support\Arrayable;
+
 interface Driver
 {
     public function forget($key, $teamId = null);
 
     public function get(string $key, $default = null, $teamId = null);
+
+    public function all($teamId = null, $keys = null): array|Arrayable;
 
     public function has($key, $teamId = null): bool;
 

--- a/src/Contracts/Driver.php
+++ b/src/Contracts/Driver.php
@@ -17,4 +17,6 @@ interface Driver
     public function has($key, $teamId = null): bool;
 
     public function set(string $key, $value = null, $teamId = null);
+
+    public function flush($teamId = null, $keys = null);
 }

--- a/src/Contracts/KeyGenerator.php
+++ b/src/Contracts/KeyGenerator.php
@@ -10,5 +10,9 @@ interface KeyGenerator
 {
     public function generate(string $key, Context $context = null): string;
 
+    public function removeContextFromKey(string $key): string;
+
     public function setContextSerializer(ContextSerializer $serializer): self;
+
+    public function contextPrefix(): string;
 }

--- a/src/Contracts/Setting.php
+++ b/src/Contracts/Setting.php
@@ -17,4 +17,6 @@ interface Setting
     public static function removeSetting($key, $teamId = null);
 
     public static function set(string $key, $value = null, $teamId = null);
+
+    public static function flush($teamId = null, $keys = null);
 }

--- a/src/Contracts/Setting.php
+++ b/src/Contracts/Setting.php
@@ -4,9 +4,13 @@ declare(strict_types=1);
 
 namespace Rawilk\Settings\Contracts;
 
+use Illuminate\Contracts\Support\Arrayable;
+
 interface Setting
 {
     public static function getValue(string $key, $default = null, $teamId = null);
+
+    public static function getAll($teamId = null, $keys = null): array|Arrayable;
 
     public static function has($key, $teamId = null): bool;
 

--- a/src/Drivers/DatabaseDriver.php
+++ b/src/Drivers/DatabaseDriver.php
@@ -46,28 +46,7 @@ class DatabaseDriver implements Driver
 
     public function all($teamId = null, $keys = null): array|Arrayable
     {
-        $keys = $this->normalizeKeys($keys);
-
-        return $this->db()
-            ->when(
-                // False means we want settings without a context set.
-                $keys === false,
-                fn (Builder $query) => $query->where('key', 'NOT LIKE', '%' . Settings::getKeyGenerator()->contextPrefix() . '%'),
-            )
-            ->when(
-                // When keys is a string, we're trying to do a partial lookup for context
-                is_string($keys),
-                fn (Builder $query) => $query->where('key', 'LIKE', "%{$keys}"),
-            )
-            ->when(
-                $keys instanceof Collection && $keys->isNotEmpty(),
-                fn (Builder $query) => $query->whereIn('key', $keys),
-            )
-            ->when(
-                $teamId !== false,
-                fn (Builder $query) => $query->where("{$this->table}.{$this->teamForeignKey}", $teamId)
-            )
-            ->get();
+        return $this->baseBulkQuery($teamId, $keys)->get();
     }
 
     public function has($key, $teamId = null): bool
@@ -94,6 +73,11 @@ class DatabaseDriver implements Driver
         $this->db()->updateOrInsert($data, compact('value'));
     }
 
+    public function flush($teamId = null, $keys = null): void
+    {
+        $this->baseBulkQuery($teamId, $keys)->delete();
+    }
+
     protected function db(): Builder
     {
         return $this->connection->table($this->table);
@@ -110,5 +94,30 @@ class DatabaseDriver implements Driver
         }
 
         return collect($keys)->flatten()->filter();
+    }
+
+    private function baseBulkQuery($teamId, $keys): Builder
+    {
+        $keys = $this->normalizeKeys($keys);
+
+        return $this->db()
+            ->when(
+                // False means we want settings without a context set.
+                $keys === false,
+                fn (Builder $query) => $query->where('key', 'NOT LIKE', '%' . Settings::getKeyGenerator()->contextPrefix() . '%'),
+            )
+            ->when(
+                // When keys is a string, we're trying to do a partial lookup for context
+                is_string($keys),
+                fn (Builder $query) => $query->where('key', 'LIKE', "%{$keys}"),
+            )
+            ->when(
+                $keys instanceof Collection && $keys->isNotEmpty(),
+                fn (Builder $query) => $query->whereIn('key', $keys),
+            )
+            ->when(
+                $teamId !== false,
+                fn (Builder $query) => $query->where("{$this->table}.{$this->teamForeignKey}", $teamId)
+            );
     }
 }

--- a/src/Drivers/DatabaseDriver.php
+++ b/src/Drivers/DatabaseDriver.php
@@ -4,9 +4,12 @@ declare(strict_types=1);
 
 namespace Rawilk\Settings\Drivers;
 
+use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Database\Connection;
 use Illuminate\Database\Query\Builder;
+use Illuminate\Support\Collection;
 use Rawilk\Settings\Contracts\Driver;
+use Rawilk\Settings\Facades\Settings;
 
 class DatabaseDriver implements Driver
 {
@@ -41,6 +44,32 @@ class DatabaseDriver implements Driver
         return $value ?? $default;
     }
 
+    public function all($teamId = null, $keys = null): array|Arrayable
+    {
+        $keys = $this->normalizeKeys($keys);
+
+        return $this->db()
+            ->when(
+                // False means we want settings without a context set.
+                $keys === false,
+                fn (Builder $query) => $query->where('key', 'NOT LIKE', '%' . Settings::getKeyGenerator()->contextPrefix() . '%'),
+            )
+            ->when(
+                // When keys is a string, we're trying to do a partial lookup for context
+                is_string($keys),
+                fn (Builder $query) => $query->where('key', 'LIKE', "%{$keys}"),
+            )
+            ->when(
+                $keys instanceof Collection && $keys->isNotEmpty(),
+                fn (Builder $query) => $query->whereIn('key', $keys),
+            )
+            ->when(
+                $teamId !== false,
+                fn (Builder $query) => $query->where("{$this->table}.{$this->teamForeignKey}", $teamId)
+            )
+            ->get();
+    }
+
     public function has($key, $teamId = null): bool
     {
         return $this->db()
@@ -68,5 +97,18 @@ class DatabaseDriver implements Driver
     protected function db(): Builder
     {
         return $this->connection->table($this->table);
+    }
+
+    protected function normalizeKeys($keys): string|Collection|bool
+    {
+        if (is_bool($keys)) {
+            return $keys;
+        }
+
+        if (is_string($keys)) {
+            return $keys;
+        }
+
+        return collect($keys)->flatten()->filter();
     }
 }

--- a/src/Drivers/EloquentDriver.php
+++ b/src/Drivers/EloquentDriver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Rawilk\Settings\Drivers;
 
+use Illuminate\Contracts\Support\Arrayable;
 use Rawilk\Settings\Contracts\Driver;
 use Rawilk\Settings\Contracts\Setting;
 
@@ -21,6 +22,11 @@ class EloquentDriver implements Driver
     public function get(string $key, $default = null, $teamId = null)
     {
         return $this->model::getValue($key, $default, $teamId);
+    }
+
+    public function all($teamId = null, $keys = null): array|Arrayable
+    {
+        return $this->model::getAll($teamId, $keys);
     }
 
     public function has($key, $teamId = null): bool

--- a/src/Drivers/EloquentDriver.php
+++ b/src/Drivers/EloquentDriver.php
@@ -38,4 +38,9 @@ class EloquentDriver implements Driver
     {
         $this->model::set($key, $value, $teamId);
     }
+
+    public function flush($teamId = null, $keys = null): void
+    {
+        $this->model::flush($teamId, $keys);
+    }
 }

--- a/src/Exceptions/InvalidBulkValueResult.php
+++ b/src/Exceptions/InvalidBulkValueResult.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rawilk\Settings\Exceptions;
+
+use Exception;
+use Illuminate\Database\Eloquent\Model;
+
+final class InvalidBulkValueResult extends Exception
+{
+    public static function notObject(): self
+    {
+        return new self('A record returned from `all()` must be an array, object, or inherit from ' . Model::class);
+    }
+
+    public static function missingValueOrKey(): self
+    {
+        return new self('A record returned from `all()` must have a `value` and `key` property.');
+    }
+}

--- a/src/Exceptions/InvalidKeyGenerator.php
+++ b/src/Exceptions/InvalidKeyGenerator.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rawilk\Settings\Exceptions;
+
+use Exception;
+use Rawilk\Settings\Support\KeyGenerators\ReadableKeyGenerator;
+
+final class InvalidKeyGenerator extends Exception
+{
+    public static function forPartialLookup(string $class): self
+    {
+        return new self(
+            "The `{$class}` key generator cannot be used for partial context setting lookups. We recommend using the " . ReadableKeyGenerator::class . ' key generator instead. You can change the `key_generator` configuration key to this value in your `config/settings.php` file.',
+        );
+    }
+}

--- a/src/Facades/Settings.php
+++ b/src/Facades/Settings.php
@@ -12,6 +12,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static \Rawilk\Settings\Settings context(null|\Rawilk\Settings\Support\Context $context = null)
  * @method static null|mixed forget($key)
  * @method static mixed get(string $key, null|mixed $default = null)
+ * @method static \Illuminate\Support\Collection all($keys)
  * @method static bool isFalse(string $key, bool|int|string $default = false)
  * @method static bool isTrue(string $key, bool|int|string $default = true)
  * @method static bool has($key)
@@ -26,6 +27,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static self enableTeams()
  * @method static self disableTeams()
  * @method static bool teamsAreEnabled()
+ * @method static \Rawilk\Settings\Contracts\KeyGenerator getKeyGenerator()
  */
 class Settings extends Facade
 {

--- a/src/Models/Setting.php
+++ b/src/Models/Setting.php
@@ -4,9 +4,12 @@ declare(strict_types=1);
 
 namespace Rawilk\Settings\Models;
 
+use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Collection;
 use Rawilk\Settings\Contracts\Setting as SettingContract;
+use Rawilk\Settings\Facades\Settings;
 
 class Setting extends Model implements SettingContract
 {
@@ -38,6 +41,35 @@ class Setting extends Model implements SettingContract
             ->value('value');
 
         return $value ?? $default;
+    }
+
+    public static function getAll($teamId = null, $keys = null): array|Arrayable
+    {
+        $keys = static::normalizeKeys($keys);
+
+        return static::query()
+            ->when(
+                // False means we want settings without a context set.
+                $keys === false,
+                fn (Builder $query) => $query->where('key', 'NOT LIKE', '%' . Settings::getKeyGenerator()->contextPrefix() . '%'),
+            )
+            ->when(
+                // When keys is a string, we're trying to do a partial lookup for context
+                is_string($keys),
+                fn (Builder $query) => $query->where('key', 'LIKE', "%{$keys}"),
+            )
+            ->when(
+                $keys instanceof Collection && $keys->isNotEmpty(),
+                fn (Builder $query) => $query->whereIn('key', $keys),
+            )
+            ->when(
+                $teamId !== false,
+                fn (Builder $query) => $query->where(
+                    static::make()->getTable() . '.' . config('settings.team_foreign_key'),
+                    $teamId,
+                ),
+            )
+            ->get();
     }
 
     public static function has($key, $teamId = null): bool
@@ -77,5 +109,18 @@ class Setting extends Model implements SettingContract
         }
 
         return static::updateOrCreate($data, compact('value'));
+    }
+
+    protected static function normalizeKeys($keys): string|Collection|bool
+    {
+        if (is_bool($keys)) {
+            return $keys;
+        }
+
+        if (is_string($keys)) {
+            return $keys;
+        }
+
+        return collect($keys)->flatten()->filter();
     }
 }

--- a/src/Models/Setting.php
+++ b/src/Models/Setting.php
@@ -45,31 +45,7 @@ class Setting extends Model implements SettingContract
 
     public static function getAll($teamId = null, $keys = null): array|Arrayable
     {
-        $keys = static::normalizeKeys($keys);
-
-        return static::query()
-            ->when(
-                // False means we want settings without a context set.
-                $keys === false,
-                fn (Builder $query) => $query->where('key', 'NOT LIKE', '%' . Settings::getKeyGenerator()->contextPrefix() . '%'),
-            )
-            ->when(
-                // When keys is a string, we're trying to do a partial lookup for context
-                is_string($keys),
-                fn (Builder $query) => $query->where('key', 'LIKE', "%{$keys}"),
-            )
-            ->when(
-                $keys instanceof Collection && $keys->isNotEmpty(),
-                fn (Builder $query) => $query->whereIn('key', $keys),
-            )
-            ->when(
-                $teamId !== false,
-                fn (Builder $query) => $query->where(
-                    static::make()->getTable() . '.' . config('settings.team_foreign_key'),
-                    $teamId,
-                ),
-            )
-            ->get();
+        return static::baseBulkQuery($teamId, $keys)->get();
     }
 
     public static function has($key, $teamId = null): bool
@@ -109,6 +85,39 @@ class Setting extends Model implements SettingContract
         }
 
         return static::updateOrCreate($data, compact('value'));
+    }
+
+    public static function flush($teamId = null, $keys = null): void
+    {
+        static::baseBulkQuery($teamId, $keys)->delete();
+    }
+
+    protected static function baseBulkQuery($teamId, $keys): Builder
+    {
+        $keys = static::normalizeKeys($keys);
+
+        return static::query()
+            ->when(
+                // False means we want settings without a context set.
+                $keys === false,
+                fn (Builder $query) => $query->where('key', 'NOT LIKE', '%' . Settings::getKeyGenerator()->contextPrefix() . '%'),
+            )
+            ->when(
+                // When keys is a string, we're trying to do a partial lookup for context
+                is_string($keys),
+                fn (Builder $query) => $query->where('key', 'LIKE', "%{$keys}"),
+            )
+            ->when(
+                $keys instanceof Collection && $keys->isNotEmpty(),
+                fn (Builder $query) => $query->whereIn('key', $keys),
+            )
+            ->when(
+                $teamId !== false,
+                fn (Builder $query) => $query->where(
+                    static::make()->getTable() . '.' . config('settings.team_foreign_key'),
+                    $teamId,
+                ),
+            );
     }
 
     protected static function normalizeKeys($keys): string|Collection|bool

--- a/src/SettingsServiceProvider.php
+++ b/src/SettingsServiceProvider.php
@@ -85,6 +85,8 @@ class SettingsServiceProvider extends PackageServiceProvider
             $app['config']['settings.encryption'] ? $settings->enableEncryption() : $settings->disableEncryption();
             $app['config']['settings.teams'] ? $settings->enableTeams() : $settings->disableTeams();
 
+            $settings->setTeamForeignKey($app['config']['settings.team_foreign_key'] ?? 'team_id');
+
             return $settings;
         });
     }

--- a/src/Support/KeyGenerators/Md5KeyGenerator.php
+++ b/src/Support/KeyGenerators/Md5KeyGenerator.php
@@ -7,6 +7,7 @@ namespace Rawilk\Settings\Support\KeyGenerators;
 use Rawilk\Settings\Contracts\ContextSerializer;
 use Rawilk\Settings\Contracts\KeyGenerator as KeyGeneratorContract;
 use Rawilk\Settings\Support\Context;
+use RuntimeException;
 
 class Md5KeyGenerator implements KeyGeneratorContract
 {
@@ -17,10 +18,20 @@ class Md5KeyGenerator implements KeyGeneratorContract
         return md5($key . $this->serializer->serialize($context));
     }
 
+    public function removeContextFromKey(string $key): string
+    {
+        throw new RuntimeException('Md5KeyGenerator does not support removing the context from the key.');
+    }
+
     public function setContextSerializer(ContextSerializer $serializer): self
     {
         $this->serializer = $serializer;
 
         return $this;
+    }
+
+    public function contextPrefix(): string
+    {
+        throw new RuntimeException('Md5KeyGenerator does not support a context prefix.');
     }
 }

--- a/src/Support/KeyGenerators/ReadableKeyGenerator.php
+++ b/src/Support/KeyGenerators/ReadableKeyGenerator.php
@@ -18,17 +18,27 @@ class ReadableKeyGenerator implements KeyGeneratorContract
         $key = $this->normalizeKey($key);
 
         if ($context) {
-            $key .= ':c:::' . $this->serializer->serialize($context);
+            $key .= $this->contextPrefix() . $this->serializer->serialize($context);
         }
 
         return $key;
     }
 
-    public function setContextSerializer(ContextSerializer $serializer): KeyGeneratorContract
+    public function removeContextFromKey(string $key): string
+    {
+        return Str::before($key, $this->contextPrefix());
+    }
+
+    public function setContextSerializer(ContextSerializer $serializer): self
     {
         $this->serializer = $serializer;
 
         return $this;
+    }
+
+    public function contextPrefix(): string
+    {
+        return ':c:::';
     }
 
     protected function normalizeKey(string $key): string

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -29,7 +29,7 @@ if (! function_exists('settings')) {
             return null;
         }
 
-        if ($context instanceof Context) {
+        if ($context instanceof Context || is_bool($context)) {
             $settings->context($context);
         }
 

--- a/tests/Feature/Drivers/DatabaseDriverTest.php
+++ b/tests/Feature/Drivers/DatabaseDriverTest.php
@@ -155,3 +155,50 @@ it('removes persisted team values', function () {
         'team_id' => 1,
     ]);
 });
+
+it('can get all persisted settings', function () {
+    $this->driver->set('one', 'value 1', false);
+    $this->driver->set('two', 'value 2', false);
+
+    $settings = $this->driver->all();
+
+    expect($settings)->toHaveCount(2)
+        ->first()->value->toBe('value 1')
+        ->and($settings[1]->value)->toBe('value 2');
+});
+
+it('can get a subset of persisted settings', function () {
+    $this->driver->set('one', 'value 1', false);
+    $this->driver->set('two', 'value 2', false);
+    $this->driver->set('three', 'value 3', false);
+
+    $settings = $this->driver->all(keys: ['one', 'three']);
+
+    expect($settings)->toHaveCount(2)
+        ->first()->value->toBe('value 1')
+        ->and($settings[1]->value)->toBe('value 3');
+});
+
+it('can get all of a teams persisted settings', function () {
+    $this->driver->set('one', 'value 1', 1);
+    $this->driver->set('two', 'value 2', 1);
+    $this->driver->set('one', 'team 2 value 1', 2);
+
+    $settings = $this->driver->all(teamId: 1);
+
+    expect($settings)->toHaveCount(2)
+        ->first()->value->toBe('value 1')
+        ->and($settings[1]->value)->toBe('value 2');
+});
+
+it('can do partial lookups on all', function () {
+    $this->driver->set('one:1', 'value 1');
+    $this->driver->set('one:2', 'value 2_1');
+    $this->driver->set('two:1', 'value 2');
+
+    $settings = $this->driver->all(keys: ':1');
+
+    expect($settings)->toHaveCount(2)
+        ->first()->value->toBe('value 1')
+        ->and($settings[1]->value)->toBe('value 2');
+});

--- a/tests/Feature/Drivers/DatabaseDriverTest.php
+++ b/tests/Feature/Drivers/DatabaseDriverTest.php
@@ -202,3 +202,46 @@ it('can do partial lookups on all', function () {
         ->first()->value->toBe('value 1')
         ->and($settings[1]->value)->toBe('value 2');
 });
+
+it('can delete all settings', function () {
+    $this->driver->set('one', 'one', false);
+    $this->driver->set('two', 'two', false);
+
+    $this->assertDatabaseCount('settings', 2);
+
+    $this->driver->flush();
+
+    $this->assertDatabaseCount('settings', 0);
+});
+
+it('can delete all team settings', function () {
+    $this->driver->set('one', 'one', 1);
+    $this->driver->set('two', 'two', 1);
+    $this->driver->set('two', 'team two', 2);
+
+    $this->assertDatabaseCount('settings', 3);
+
+    $this->driver->flush(teamId: 1);
+
+    $this->assertDatabaseCount('settings', 1);
+});
+
+it('can flush a subset of settings', function () {
+    $this->driver->set('one', 'one', false);
+    $this->driver->set('two', 'two', false);
+    $this->driver->set('three', 'three', false);
+
+    $this->assertDatabaseCount('settings', 3);
+
+    $this->driver->flush(keys: ['one', 'three']);
+
+    $this->assertDatabaseCount('settings', 1);
+
+    $this->assertDatabaseMissing('settings', [
+        'key' => 'one',
+    ]);
+
+    $this->assertDatabaseMissing('settings', [
+        'key' => 'three',
+    ]);
+});

--- a/tests/Feature/Drivers/EloquentDriverTest.php
+++ b/tests/Feature/Drivers/EloquentDriverTest.php
@@ -149,3 +149,50 @@ it('removes persisted team values', function () {
         'team_id' => 1,
     ]);
 });
+
+it('can get all persisted settings', function () {
+    $this->driver->set('one', 'value 1', false);
+    $this->driver->set('two', 'value 2', false);
+
+    $settings = $this->driver->all();
+
+    expect($settings)->toHaveCount(2)
+        ->first()->value->toBe('value 1')
+        ->and($settings[1]->value)->toBe('value 2');
+});
+
+it('can get a subset of persisted settings', function () {
+    $this->driver->set('one', 'value 1', false);
+    $this->driver->set('two', 'value 2', false);
+    $this->driver->set('three', 'value 3', false);
+
+    $settings = $this->driver->all(keys: ['one', 'three']);
+
+    expect($settings)->toHaveCount(2)
+        ->first()->value->toBe('value 1')
+        ->and($settings[1]->value)->toBe('value 3');
+});
+
+it('can get all of a teams persisted settings', function () {
+    $this->driver->set('one', 'value 1', 1);
+    $this->driver->set('two', 'value 2', 1);
+    $this->driver->set('one', 'team 2 value 1', 2);
+
+    $settings = $this->driver->all(teamId: 1);
+
+    expect($settings)->toHaveCount(2)
+        ->first()->value->toBe('value 1')
+        ->and($settings[1]->value)->toBe('value 2');
+});
+
+it('can do partial lookups on all', function () {
+    $this->driver->set('one:1', 'value 1');
+    $this->driver->set('one:2', 'value 2_1');
+    $this->driver->set('two:1', 'value 2');
+
+    $settings = $this->driver->all(keys: ':1');
+
+    expect($settings)->toHaveCount(2)
+        ->first()->value->toBe('value 1')
+        ->and($settings[1]->value)->toBe('value 2');
+});

--- a/tests/Feature/Drivers/EloquentDriverTest.php
+++ b/tests/Feature/Drivers/EloquentDriverTest.php
@@ -196,3 +196,46 @@ it('can do partial lookups on all', function () {
         ->first()->value->toBe('value 1')
         ->and($settings[1]->value)->toBe('value 2');
 });
+
+it('can delete all settings', function () {
+    $this->driver->set('one', 'one', false);
+    $this->driver->set('two', 'two', false);
+
+    $this->assertDatabaseCount('settings', 2);
+
+    $this->driver->flush();
+
+    $this->assertDatabaseCount('settings', 0);
+});
+
+it('can delete all team settings', function () {
+    $this->driver->set('one', 'one', 1);
+    $this->driver->set('two', 'two', 1);
+    $this->driver->set('two', 'team two', 2);
+
+    $this->assertDatabaseCount('settings', 3);
+
+    $this->driver->flush(teamId: 1);
+
+    $this->assertDatabaseCount('settings', 1);
+});
+
+it('can flush a subset of settings', function () {
+    $this->driver->set('one', 'one', false);
+    $this->driver->set('two', 'two', false);
+    $this->driver->set('three', 'three', false);
+
+    $this->assertDatabaseCount('settings', 3);
+
+    $this->driver->flush(keys: ['one', 'three']);
+
+    $this->assertDatabaseCount('settings', 1);
+
+    $this->assertDatabaseMissing('settings', [
+        'key' => 'one',
+    ]);
+
+    $this->assertDatabaseMissing('settings', [
+        'key' => 'three',
+    ]);
+});

--- a/tests/Feature/HasSettingsTest.php
+++ b/tests/Feature/HasSettingsTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 use Rawilk\Settings\Facades\Settings;
 use Rawilk\Settings\Support\Context;
+use Rawilk\Settings\Support\ContextSerializers\DotNotationContextSerializer;
+use Rawilk\Settings\Support\KeyGenerators\ReadableKeyGenerator;
 use Rawilk\Settings\Tests\Support\Models\Company;
 use Rawilk\Settings\Tests\Support\Models\CustomUser;
 use Rawilk\Settings\Tests\Support\Models\User;
@@ -75,4 +77,53 @@ test('models can have their own settings', function () {
 
     expect(Settings::context($user1Context)->get('program.name'))->toBe($user1->email)
         ->and(Settings::context($user2Context)->get('program.name'))->toBe($user2->email);
+});
+
+test("a model's settings are flushed when the model is deleted", function () {
+    $settings = settings();
+    (fn () => $this->keyGenerator = (new ReadableKeyGenerator)->setContextSerializer(new DotNotationContextSerializer))->call($settings);
+
+    $user1 = User::first();
+    $user2 = User::where('id', '>', $user1->getKey())->first();
+
+    Settings::set('user.email', 'foo');
+
+    $user1->settings()->set('user.email', $user1->email);
+    $user2->settings()->set('user.email', $user2->email);
+
+    $this->assertDatabaseCount('settings', 3);
+
+    $user1->delete();
+
+    $this->assertDatabaseCount('settings', 2);
+
+    $this->assertDatabaseMissing('settings', [
+        'key' => 'user.email:c:::model:user::id:' . $user1->getKey(),
+    ]);
+});
+
+test('a model can be configured to not flush settings on delete', function () {
+    $settings = settings();
+    (fn () => $this->keyGenerator = (new ReadableKeyGenerator)->setContextSerializer(new DotNotationContextSerializer))->call($settings);
+
+    $company = Company::factory()->create();
+    $company->settings()->set('foo', 'bar');
+
+    $this->assertDatabaseCount('settings', 1);
+
+    $company->delete();
+
+    $this->assertDatabaseCount('settings', 1);
+});
+
+test("a model's settings will not be flushed if the md5 key generator is being used", function () {
+    $user = User::first();
+
+    $user->settings()->set('foo', 'bar');
+
+    $this->assertDatabaseCount('settings', 1);
+
+    $user->delete();
+
+    $this->assertDatabaseCount('settings', 1);
 });

--- a/tests/Support/Drivers/CustomDriver.php
+++ b/tests/Support/Drivers/CustomDriver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Rawilk\Settings\Tests\Support\Drivers;
 
+use Illuminate\Contracts\Support\Arrayable;
 use Rawilk\Settings\Contracts\Driver;
 
 final class CustomDriver implements Driver
@@ -26,5 +27,10 @@ final class CustomDriver implements Driver
     public function set(string $key, $value = null, $teamId = null): void
     {
         //
+    }
+
+    public function all($teamId = null, $keys = null): array|Arrayable
+    {
+        return [];
     }
 }

--- a/tests/Support/Drivers/CustomDriver.php
+++ b/tests/Support/Drivers/CustomDriver.php
@@ -33,4 +33,8 @@ final class CustomDriver implements Driver
     {
         return [];
     }
+
+    public function flush($teamId = null, $keys = null): void
+    {
+    }
 }

--- a/tests/Support/Models/Company.php
+++ b/tests/Support/Models/Company.php
@@ -14,6 +14,8 @@ final class Company extends Model
     use HasFactory;
     use HasSettings;
 
+    protected static bool $flushSettingsOnDelete = false;
+
     protected static function newFactory(): CompanyFactory
     {
         return new CompanyFactory;


### PR DESCRIPTION
PR adds ability to fetch and flush all settings.

All settings can be fetched at once using `all()` on the Settings facade. If an array of setting keys are passed in to all, only those specific keys will be fetched. If a context object is supplied (via `settings()->context(...)`, only settings applicable to that context are fetched. A `false` value may also be supplied for the context, which will only return settings that don't have a context applied to it.

As a note, fetching settings via `all()` does not use the cache at all. As of right now, I'm not sure of a good way to generate a cache key for multiple settings and even if there was a way, I'm not sure of a good way to bust the cache for those grouped settings when a single setting is updated or deleted using `set()` and `forget()`.