### PR TITLE
Dispatch Events

### DIFF
--- a/src/Events/SettingWasDeleted.php
+++ b/src/Events/SettingWasDeleted.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rawilk\Settings\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+use Rawilk\Settings\Support\Context;
+
+final class SettingWasDeleted
+{
+    use Dispatchable;
+    use SerializesModels;
+
+    public function __construct(
+        public string $key,
+        public string $storageKey,
+        public string $cacheKey,
+        public mixed $teamId,
+        public bool|Context|null $context,
+    ) {
+    }
+}

--- a/src/Events/SettingWasStored.php
+++ b/src/Events/SettingWasStored.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rawilk\Settings\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+use Rawilk\Settings\Support\Context;
+
+final class SettingWasStored
+{
+    use Dispatchable;
+    use SerializesModels;
+
+    public function __construct(
+        public string $key,
+        public string $storageKey,
+        public string $cacheKey,
+        public mixed $value,
+        public mixed $teamId,
+        public bool|Context|null $context,
+    ) {
+    }
+}

--- a/src/Events/SettingsFlushed.php
+++ b/src/Events/SettingsFlushed.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rawilk\Settings\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Collection;
+use Rawilk\Settings\Support\Context;
+
+final class SettingsFlushed
+{
+    use Dispatchable;
+    use SerializesModels;
+
+    public function __construct(
+        public bool|Collection|string $keys,
+        public mixed $teamId,
+        public bool|Context|null $context,
+    ) {
+    }
+}

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -14,6 +14,7 @@ use Rawilk\Settings\Contracts\Driver;
 use Rawilk\Settings\Contracts\KeyGenerator;
 use Rawilk\Settings\Contracts\ValueSerializer;
 use Rawilk\Settings\Events\SettingsFlushed;
+use Rawilk\Settings\Events\SettingWasDeleted;
 use Rawilk\Settings\Exceptions\InvalidBulkValueResult;
 use Rawilk\Settings\Exceptions\InvalidKeyGenerator;
 use Rawilk\Settings\Support\Context;
@@ -115,6 +116,14 @@ class Settings
         $driverResult = $this->driver->forget(
             key: $generatedKey,
             teamId: $this->teams ? $this->teamId : false,
+        );
+
+        SettingWasDeleted::dispatch(
+            $key,
+            $generatedKey,
+            $this->getCacheKey($generatedKey),
+            $this->teams ? $this->teamId : false,
+            $this->context,
         );
 
         if ($this->temporarilyDisableCache || $this->cacheIsEnabled()) {

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -13,6 +13,7 @@ use Illuminate\Support\Traits\Macroable;
 use Rawilk\Settings\Contracts\Driver;
 use Rawilk\Settings\Contracts\KeyGenerator;
 use Rawilk\Settings\Contracts\ValueSerializer;
+use Rawilk\Settings\Events\SettingsFlushed;
 use Rawilk\Settings\Exceptions\InvalidBulkValueResult;
 use Rawilk\Settings\Exceptions\InvalidKeyGenerator;
 use Rawilk\Settings\Support\Context;
@@ -270,6 +271,12 @@ class Settings
         $driverResult = $this->driver->flush(
             teamId: $this->teams ? $this->teamId : false,
             keys: $keys,
+        );
+
+        SettingsFlushed::dispatch(
+            $keys,
+            $this->teams ? $this->teamId : false,
+            $this->context,
         );
 
         // Flush the cache for all deleted keys.

--- a/tests/ArchTest.php
+++ b/tests/ArchTest.php
@@ -3,6 +3,8 @@
 declare(strict_types=1);
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Facades\Facade;
 use Rawilk\Settings\Contracts\ContextSerializer;
 use Rawilk\Settings\Contracts\Driver;
@@ -54,3 +56,14 @@ test('key generators are configured correctly')
     ->toImplement(KeyGenerator::class)
     ->toExtendNothing()
     ->toHaveSuffix('Generator');
+
+test('events are configured correctly')
+    ->expect('Rawilk\Settings\Events')
+    ->toBeClasses()
+    ->classes()
+    ->toExtendNothing()
+    ->toBeFinal()
+    ->toUse([
+        Dispatchable::class,
+        SerializesModels::class,
+    ]);

--- a/tests/Feature/SettingsTest.php
+++ b/tests/Feature/SettingsTest.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Facades\Event;
 use Rawilk\Settings\Contracts\Setting;
 use Rawilk\Settings\Drivers\EloquentDriver;
 use Rawilk\Settings\Events\SettingsFlushed;
+use Rawilk\Settings\Events\SettingWasDeleted;
 use Rawilk\Settings\Exceptions\InvalidKeyGenerator;
 use Rawilk\Settings\Facades\Settings as SettingsFacade;
 use Rawilk\Settings\Support\Context;
@@ -445,6 +446,19 @@ it('dispatches an event when settings are flushed', function () {
     $settings->flush();
 
     Event::assertDispatched(SettingsFlushed::class);
+});
+
+it('dispatches an event when a setting is deleted', function () {
+    Event::fake();
+
+    SettingsFacade::set('foo', 'bar');
+    SettingsFacade::forget('foo');
+
+    Event::assertDispatched(function (SettingWasDeleted $event) {
+        return $event->key === 'foo'
+            && $event->teamId === false
+            && is_null($event->context);
+    });
 });
 
 // Helpers...

--- a/tests/Feature/SettingsTest.php
+++ b/tests/Feature/SettingsTest.php
@@ -3,8 +3,10 @@
 declare(strict_types=1);
 
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Event;
 use Rawilk\Settings\Contracts\Setting;
 use Rawilk\Settings\Drivers\EloquentDriver;
+use Rawilk\Settings\Events\SettingsFlushed;
 use Rawilk\Settings\Exceptions\InvalidKeyGenerator;
 use Rawilk\Settings\Facades\Settings as SettingsFacade;
 use Rawilk\Settings\Support\Context;
@@ -429,6 +431,20 @@ it('can flush settings base on context', function () {
     $settings->context($context)->flush();
 
     $this->assertDatabaseCount('settings', 1);
+});
+
+it('dispatches an event when settings are flushed', function () {
+    $settings = settings();
+    (fn () => $this->keyGenerator = (new ReadableKeyGenerator)->setContextSerializer(new DotNotationContextSerializer))->call($settings);
+
+    Event::fake();
+
+    $settings->set('one', 'value 1');
+    $settings->set('two', 'value 2');
+
+    $settings->flush();
+
+    Event::assertDispatched(SettingsFlushed::class);
 });
 
 // Helpers...


### PR DESCRIPTION
This PR adds three events that will be dispatched:

### SettingsFlushed

Event is dispatched when the `flush` method is called on the settings service. The event receives the following arguments:

- `$keys`: The subset of keys being flushed, if any
- `$teamId`: The current team id set on the settings service
-  `$context`: The current context object set on the settings service

### SettingWasDeleted

Event is dispatched when a setting is deleted. The event receives the following arguments:

- `$key`: The key of the setting being deleted
- `$storageKey`: The generated key used by the storage mechanism on the driver
- `$cacheKey`: The generated cache key of the setting
- `$teamId`: The current team id set on the settings service
-  `$context`: The current context object set on the settings service

### SettingWasStored

Event is dispatched when a setting is deleted. The event receives the following arguments:

- `$key`: The key of the setting being stored
- `$storageKey`: The generated key used by the storage mechanism on the driver
- `$cacheKey`: The generated cache key of the setting
- `$value`: The value being set for the setting
- `$teamId`: The current team id set on the settings service
-  `$context`: The current context object set on the settings service

**Note:** When caching is enabled, the event will only fire if the value has changed for an already persisted setting.