### PR TITLE
Disable caching of the default value if configured that way

### DIFF
--- a/config/settings.php
+++ b/config/settings.php
@@ -163,4 +163,16 @@ return [
     |
     */
     'value_serializer' => \Rawilk\Settings\Support\ValueSerializers\ValueSerializer::class,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Cache Default Value
+    |--------------------------------------------------------------------------
+    |
+    | When a setting is not persisted, we will cache the passed in default value
+    | if this is set to true. This may not always be desirable, so you can
+    | disable it here if needed.
+    |
+    */
+    'cache_default_value' => true,
 ];

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -44,6 +44,12 @@ class Settings
     // Meant for internal use only.
     protected bool $resetContext = true;
 
+    /**
+     * If true, we will cache the default value for a setting when it is not persisted
+     * when trying to retrieve it.
+     */
+    protected bool $cacheDefaultValue = true;
+
     protected bool $teams = false;
 
     /** @var null|string|int */
@@ -110,6 +116,13 @@ class Settings
         return $this;
     }
 
+    public function cacheDefaultValue(bool $cacheDefaultValue = true): self
+    {
+        $this->cacheDefaultValue = $cacheDefaultValue;
+
+        return $this;
+    }
+
     public function forget(string|BackedEnum $key)
     {
         $key = $this->normalizeKey($key);
@@ -154,7 +167,7 @@ class Settings
                 $this->getCacheKey($generatedKey),
                 fn () => $this->driver->get(
                     key: $generatedKey,
-                    default: $default,
+                    default: $this->cacheDefaultValue ? $default : null,
                     teamId: $this->teams ? $this->teamId : false,
                 )
             );

--- a/src/SettingsServiceProvider.php
+++ b/src/SettingsServiceProvider.php
@@ -77,6 +77,8 @@ class SettingsServiceProvider extends PackageServiceProvider
 
             $settings->setCache($app['cache.store']);
 
+            $settings->cacheDefaultValue($app['config']['settings.cache_default_value'] ?? false);
+
             if (config('app.key')) {
                 $settings->setEncrypter($app['encrypter']);
             }

--- a/tests/Feature/SettingsTest.php
+++ b/tests/Feature/SettingsTest.php
@@ -27,6 +27,7 @@ beforeEach(function () {
         'settings.table' => 'settings',
         'settings.cache' => false,
         'settings.encryption' => false,
+        'settings.cache_default_value' => true,
     ]);
 
     setDatabaseDriverConnection();
@@ -516,6 +517,20 @@ it('accepts a backed enum for a key instead of a string', function () {
 it('throws an exception when an int backed enum is used', function () {
     SettingsFacade::get(InvalidEnumTypeEnum::Foo);
 })->throws(InvalidEnumType::class);
+
+test('if configured to not cache default values, it does not cache the default value if the requested setting is not persisted', function () {
+    settings()->enableCache()->cacheDefaultValue(false);
+
+    expect(settings()->get('foo', 'default value 1'))->toBe('default value 1')
+        ->and(settings()->get('foo', 'default value 2'))->toBe('default value 2');
+});
+
+it('caches the default value if configured to', function () {
+    settings()->enableCache()->cacheDefaultValue(true);
+
+    expect(settings()->get('foo', 'default value 1'))->toBe('default value 1')
+        ->and(settings()->get('foo', 'default value 2'))->toBe('default value 1');
+});
 
 // Helpers...
 


### PR DESCRIPTION
An issue was brought up in issue #39 where it can be confusing that the default value passed into `settings()->get()` is cached and not documented - see https://github.com/rawilk/laravel-settings/issues/39#issuecomment-1747228762. This PR adds a `cache_default_value` configuration option. When set to `false`, the package will not cache the value of the default value passed in. The following code will work as expected with this new configuration option set to false.

```php
$language = settings()->get('site.lang', 'en'); // 'en'

// some other code

// `site.lang` is still not persisted at this point, so the
//  default value we provide the function should be the value returned.
$language = settings()->get('site.lang', 'es'); // 'es'
```

This configuration option will be set to `true` by default, however in future major versions, it may default to `false`.