### PR TITLE
Update docs for new `cache_default_value` config option

### DIFF
--- a/docs/basic-usage/basic-usage.md
+++ b/docs/basic-usage/basic-usage.md
@@ -26,6 +26,9 @@ Settings::get('foo');
 Settings::get('not persisted', 'my default'); // 'my default'
 ```
 
+> {note} By default, the default value passed into `get()` will be cached. This may not always be desirable, and can be
+> disabled by setting the `cache_default_value` config option to `false` in the `config/settings.php` file.
+
 ## Check if a setting exists
 
 ```php

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -48,3 +48,29 @@ allowing the package to search for settings easier by key, and partial searches 
 ```
 
 For more information on the key generators, see the [Custom Generators](/docs/laravel-settings/{version}/advanced-usage/custom-generators) documentation.
+
+#### Default Values
+
+When caching is enabled, and you are attempting to retrieve a setting that is not persisted yet, the settings service will cache the default value provided to `get()`.
+This means that any subsequent calls to `get()` for that setting will return the original default value provided to it until the setting is persisted.
+
+This may not always be desirable, but this functionality can easily be disabled in the configuration file:
+
+```php
+// config/settings.php
+'cache_default_value' => false,
+```
+
+With that value set to `false`, the following code will work as expected for retrieving a setting that hasn't been persisted yet:
+
+```php
+settings()->get('site.lang', 'en'); // 'en'
+
+// somewhere else in the codebase
+
+settings()->get('site.lang', 'es'); // 'es'
+```
+
+For more information on retrieving a value, see [Retrieving a value](/docs/laravel-settings/{version}/basic-usage#user-content-retrieving-a-value) in the docs.
+
+> {tip} This configuration value is set to `true` by default, however in future major versions of this package, it may be defaulted to `false`.

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -106,6 +106,18 @@ The following configuration options should be added to your `config/settings.php
     |
     */
     'value_serializer' => \Rawilk\Settings\Support\ValueSerializers\ValueSerializer::class,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Cache Default Value
+    |--------------------------------------------------------------------------
+    |
+    | When a setting is not persisted, we will cache the passed in default value
+    | if this is set to true. This may not always be desirable, so you can
+    | disable it here if needed.
+    |
+    */
+    'cache_default_value' => true,
 ```
 
 ### Migrations


### PR DESCRIPTION
Update the docs to reflect the new `cache_default_value` configuration option and the describe how the default value is cached by default better.
