### PR TITLE
Add ability to set team id on a single call

### DIFF
--- a/src/Facades/Settings.php
+++ b/src/Facades/Settings.php
@@ -28,6 +28,8 @@ use Illuminate\Support\Facades\Facade;
  * @method static self enableTeams()
  * @method static self disableTeams()
  * @method static bool teamsAreEnabled()
+ * @method static self usingTeam(mixed $teamId)
+ * @method static self withoutTeams()
  * @method static \Rawilk\Settings\Contracts\KeyGenerator getKeyGenerator()
  * @method static string cacheKeyForSetting(string $key)
  */


### PR DESCRIPTION
There may be some situations that come up where you either want or don't want a specific setting call to be scoped to a team. For example, in a multi-tenant setup, you may allow an admin to set a tenant specific setting without messing up the current team id. With this PR, this is now possible via:

- `settings()->usingTeam('team-id')->set(...)`
- `settings()->withoutTeams()->set(...)`
