### PR TITLE
Add safelist for object unserialization

### DIFF
--- a/config/settings.php
+++ b/config/settings.php
@@ -175,4 +175,22 @@ return [
     |
     */
     'cache_default_value' => true,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Unserialize Safelist
+    |--------------------------------------------------------------------------
+    |
+    | When using the default value serializer class from this package, we
+    | will only unserialize objects that have their classes whitelisted here.
+    | Any other objects will be unserialized to something like:
+    | __PHP_Incomplete_Class(App\Models\User) {...}
+    |
+    | To prevent any objects from being unserialized, simply set this to
+    | an empty array.
+    */
+    'unserialize_safelist' => [
+        \Carbon\Carbon::class,
+        \Carbon\CarbonImmutable::class,
+    ],
 ];

--- a/src/Support/ValueSerializers/ValueSerializer.php
+++ b/src/Support/ValueSerializers/ValueSerializer.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Rawilk\Settings\Support\ValueSerializers;
 
+use Illuminate\Support\Arr;
 use Rawilk\Settings\Contracts\ValueSerializer as ValueSerializerContract;
 
 class ValueSerializer implements ValueSerializerContract
@@ -15,6 +16,8 @@ class ValueSerializer implements ValueSerializerContract
 
     public function unserialize(string $serialized): mixed
     {
-        return unserialize($serialized, ['allowed_classes' => false]);
+        $safelistedClasses = Arr::wrap(config('settings.unserialize_safelist', []));
+
+        return unserialize($serialized, ['allowed_classes' => $safelistedClasses]);
     }
 }


### PR DESCRIPTION
An issue (#46) was raised that describes an issue with not being able to store any kind of object in settings, since they will be unserialized to an object like `__PHP_Incomplete_Class(...)`. While the default `ValueSerializer` can be overridden so that any objects can be unserialized properly, it may not always be desirable to create a custom class implementation of your own. 

This PR adds a `unserialize_safelist` configuration option to allow you to specify which classes should be allowed to be unserialized. By default, we'll allow carbon date objects to be unserialized, but you are free to add more to the config.