### PR TITLE
[Feature]: Hash key generator

### DIFF
--- a/config/settings.php
+++ b/config/settings.php
@@ -145,6 +145,7 @@ return [
     | Supported:
     | - \Rawilk\Settings\Support\KeyGenerators\ReadableKeyGenerator
     | - \Rawilk\Settings\Support\KeyGenerators\Md5KeyGenerator (default)
+    | - \Rawilk\Settings\Support\KeyGenerators\HashKeyGenerator
     |
     */
     'key_generator' => \Rawilk\Settings\Support\KeyGenerators\Md5KeyGenerator::class,
@@ -194,4 +195,14 @@ return [
         \Carbon\CarbonImmutable::class,
         \Illuminate\Support\Carbon::class,
     ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Hash Algorithm
+    |--------------------------------------------------------------------------
+    |
+    | The hashing algorithm to use for the HashKeyGenerator.
+    |
+    */
+    'hash_algorithm' => 'xxh128',
 ];

--- a/src/Contracts/ContextSerializer.php
+++ b/src/Contracts/ContextSerializer.php
@@ -8,5 +8,5 @@ use Rawilk\Settings\Support\Context;
 
 interface ContextSerializer
 {
-    public function serialize(?Context $context = null): string;
+    public function serialize(Context $context = null): string;
 }

--- a/src/Contracts/ContextSerializer.php
+++ b/src/Contracts/ContextSerializer.php
@@ -8,5 +8,5 @@ use Rawilk\Settings\Support\Context;
 
 interface ContextSerializer
 {
-    public function serialize(Context $context = null): string;
+    public function serialize(?Context $context = null): string;
 }

--- a/src/Contracts/KeyGenerator.php
+++ b/src/Contracts/KeyGenerator.php
@@ -8,7 +8,7 @@ use Rawilk\Settings\Support\Context;
 
 interface KeyGenerator
 {
-    public function generate(string $key, ?Context $context = null): string;
+    public function generate(string $key, Context $context = null): string;
 
     public function removeContextFromKey(string $key): string;
 

--- a/src/Contracts/KeyGenerator.php
+++ b/src/Contracts/KeyGenerator.php
@@ -8,7 +8,7 @@ use Rawilk\Settings\Support\Context;
 
 interface KeyGenerator
 {
-    public function generate(string $key, Context $context = null): string;
+    public function generate(string $key, ?Context $context = null): string;
 
     public function removeContextFromKey(string $key): string;
 

--- a/src/Drivers/DatabaseDriver.php
+++ b/src/Drivers/DatabaseDriver.php
@@ -17,8 +17,7 @@ class DatabaseDriver implements Driver
         protected Connection $connection,
         protected string $table,
         protected ?string $teamForeignKey = null,
-    ) {
-    }
+    ) {}
 
     public function forget($key, $teamId = null): void
     {

--- a/src/Drivers/EloquentDriver.php
+++ b/src/Drivers/EloquentDriver.php
@@ -10,9 +10,7 @@ use Rawilk\Settings\Contracts\Setting;
 
 class EloquentDriver implements Driver
 {
-    public function __construct(protected Setting $model)
-    {
-    }
+    public function __construct(protected Setting $model) {}
 
     public function forget($key, $teamId = null): void
     {

--- a/src/Drivers/Factory.php
+++ b/src/Drivers/Factory.php
@@ -17,11 +17,9 @@ class Factory
 
     protected array $customCreators = [];
 
-    public function __construct(protected Application $app)
-    {
-    }
+    public function __construct(protected Application $app) {}
 
-    public function driver(string $driver = null): Driver
+    public function driver(?string $driver = null): Driver
     {
         return $this->resolveDriver($driver);
     }
@@ -64,7 +62,7 @@ class Factory
         return $this->app['config']["settings.drivers.{$driver}"];
     }
 
-    protected function resolveDriver(string $driver = null): Driver
+    protected function resolveDriver(?string $driver = null): Driver
     {
         $driver = $driver ?: $this->getDefaultDriver();
 

--- a/src/Drivers/Factory.php
+++ b/src/Drivers/Factory.php
@@ -21,7 +21,7 @@ class Factory
     {
     }
 
-    public function driver(?string $driver = null): Driver
+    public function driver(string $driver = null): Driver
     {
         return $this->resolveDriver($driver);
     }
@@ -64,7 +64,7 @@ class Factory
         return $this->app['config']["settings.drivers.{$driver}"];
     }
 
-    protected function resolveDriver(?string $driver = null): Driver
+    protected function resolveDriver(string $driver = null): Driver
     {
         $driver = $driver ?: $this->getDefaultDriver();
 

--- a/src/Events/SettingWasDeleted.php
+++ b/src/Events/SettingWasDeleted.php
@@ -19,6 +19,5 @@ final class SettingWasDeleted
         public string $cacheKey,
         public mixed $teamId,
         public bool|Context|null $context,
-    ) {
-    }
+    ) {}
 }

--- a/src/Events/SettingWasStored.php
+++ b/src/Events/SettingWasStored.php
@@ -20,6 +20,5 @@ final class SettingWasStored
         public mixed $value,
         public mixed $teamId,
         public bool|Context|null $context,
-    ) {
-    }
+    ) {}
 }

--- a/src/Events/SettingsFlushed.php
+++ b/src/Events/SettingsFlushed.php
@@ -18,6 +18,5 @@ final class SettingsFlushed
         public bool|Collection|string $keys,
         public mixed $teamId,
         public bool|Context|null $context,
-    ) {
-    }
+    ) {}
 }

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -66,8 +66,7 @@ class Settings
         protected Driver $driver,
         protected KeyGenerator $keyGenerator,
         protected ValueSerializer $valueSerializer,
-    ) {
-    }
+    ) {}
 
     // mainly for testing purposes
     public function getDriver(): Driver
@@ -79,7 +78,7 @@ class Settings
      * Pass in `false` for context when calling `all()` to only return results
      * that do not have context.
      */
-    public function context(Context|bool $context = null): self
+    public function context(Context|bool|null $context = null): self
     {
         $this->context = $context;
 

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -79,7 +79,7 @@ class Settings
      * Pass in `false` for context when calling `all()` to only return results
      * that do not have context.
      */
-    public function context(Context|bool|null $context = null): self
+    public function context(Context|bool $context = null): self
     {
         $this->context = $context;
 

--- a/src/Support/ContextSerializers/ContextSerializer.php
+++ b/src/Support/ContextSerializers/ContextSerializer.php
@@ -9,7 +9,7 @@ use Rawilk\Settings\Support\Context;
 
 class ContextSerializer implements ContextSerializerContract
 {
-    public function serialize(?Context $context = null): string
+    public function serialize(Context $context = null): string
     {
         return serialize($context);
     }

--- a/src/Support/ContextSerializers/ContextSerializer.php
+++ b/src/Support/ContextSerializers/ContextSerializer.php
@@ -9,7 +9,7 @@ use Rawilk\Settings\Support\Context;
 
 class ContextSerializer implements ContextSerializerContract
 {
-    public function serialize(Context $context = null): string
+    public function serialize(?Context $context = null): string
     {
         return serialize($context);
     }

--- a/src/Support/ContextSerializers/DotNotationContextSerializer.php
+++ b/src/Support/ContextSerializers/DotNotationContextSerializer.php
@@ -9,7 +9,7 @@ use Rawilk\Settings\Support\Context;
 
 class DotNotationContextSerializer implements ContextSerializerContract
 {
-    public function serialize(?Context $context = null): string
+    public function serialize(Context $context = null): string
     {
         if (is_null($context)) {
             return '';

--- a/src/Support/ContextSerializers/DotNotationContextSerializer.php
+++ b/src/Support/ContextSerializers/DotNotationContextSerializer.php
@@ -9,7 +9,7 @@ use Rawilk\Settings\Support\Context;
 
 class DotNotationContextSerializer implements ContextSerializerContract
 {
-    public function serialize(Context $context = null): string
+    public function serialize(?Context $context = null): string
     {
         if (is_null($context)) {
             return '';

--- a/src/Support/KeyGenerators/HashKeyGenerator.php
+++ b/src/Support/KeyGenerators/HashKeyGenerator.php
@@ -13,7 +13,7 @@ class HashKeyGenerator implements KeyGeneratorContract
 {
     protected ContextSerializer $serializer;
 
-    public function generate(string $key, Context $context = null): string
+    public function generate(string $key, ?Context $context = null): string
     {
         return hash(
             config('settings.hash_algorithm', 'xxh128'),

--- a/src/Support/KeyGenerators/HashKeyGenerator.php
+++ b/src/Support/KeyGenerators/HashKeyGenerator.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rawilk\Settings\Support\KeyGenerators;
+
+use Rawilk\Settings\Contracts\ContextSerializer;
+use Rawilk\Settings\Contracts\KeyGenerator as KeyGeneratorContract;
+use Rawilk\Settings\Support\Context;
+use RuntimeException;
+
+class HashKeyGenerator implements KeyGeneratorContract
+{
+    protected ContextSerializer $serializer;
+
+    public function generate(string $key, Context $context = null): string
+    {
+        return hash(
+            config('settings.hash_algorithm', 'xxh128'),
+            $key . $this->serializer->serialize($context),
+        );
+    }
+
+    public function removeContextFromKey(string $key): string
+    {
+        throw new RuntimeException('HashKeyGenerator does not support removing the context from the key.');
+    }
+
+    public function setContextSerializer(ContextSerializer $serializer): static
+    {
+        $this->serializer = $serializer;
+
+        return $this;
+    }
+
+    public function contextPrefix(): string
+    {
+        throw new RuntimeException('HashKeyGenerator does not support a context prefix.');
+    }
+}

--- a/src/Support/KeyGenerators/Md5KeyGenerator.php
+++ b/src/Support/KeyGenerators/Md5KeyGenerator.php
@@ -13,7 +13,7 @@ class Md5KeyGenerator implements KeyGeneratorContract
 {
     protected ContextSerializer $serializer;
 
-    public function generate(string $key, Context $context = null): string
+    public function generate(string $key, ?Context $context = null): string
     {
         return md5($key . $this->serializer->serialize($context));
     }

--- a/src/Support/KeyGenerators/Md5KeyGenerator.php
+++ b/src/Support/KeyGenerators/Md5KeyGenerator.php
@@ -13,7 +13,7 @@ class Md5KeyGenerator implements KeyGeneratorContract
 {
     protected ContextSerializer $serializer;
 
-    public function generate(string $key, ?Context $context = null): string
+    public function generate(string $key, Context $context = null): string
     {
         return md5($key . $this->serializer->serialize($context));
     }

--- a/src/Support/KeyGenerators/ReadableKeyGenerator.php
+++ b/src/Support/KeyGenerators/ReadableKeyGenerator.php
@@ -13,7 +13,7 @@ class ReadableKeyGenerator implements KeyGeneratorContract
 {
     protected ContextSerializer $serializer;
 
-    public function generate(string $key, Context $context = null): string
+    public function generate(string $key, ?Context $context = null): string
     {
         $key = $this->normalizeKey($key);
 

--- a/src/Support/KeyGenerators/ReadableKeyGenerator.php
+++ b/src/Support/KeyGenerators/ReadableKeyGenerator.php
@@ -13,7 +13,7 @@ class ReadableKeyGenerator implements KeyGeneratorContract
 {
     protected ContextSerializer $serializer;
 
-    public function generate(string $key, ?Context $context = null): string
+    public function generate(string $key, Context $context = null): string
     {
         $key = $this->normalizeKey($key);
 

--- a/tests/Support/Drivers/CustomDriver.php
+++ b/tests/Support/Drivers/CustomDriver.php
@@ -34,7 +34,5 @@ final class CustomDriver implements Driver
         return [];
     }
 
-    public function flush($teamId = null, $keys = null): void
-    {
-    }
+    public function flush($teamId = null, $keys = null): void {}
 }

--- a/tests/Unit/KeyGenerators/HashKeyGeneratorTest.php
+++ b/tests/Unit/KeyGenerators/HashKeyGeneratorTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+use Rawilk\Settings\Support\Context;
+use Rawilk\Settings\Support\ContextSerializers\ContextSerializer;
+use Rawilk\Settings\Support\ContextSerializers\DotNotationContextSerializer;
+use Rawilk\Settings\Support\KeyGenerators\HashKeyGenerator;
+
+beforeEach(function () {
+    $this->keyGenerator = (new HashKeyGenerator)
+        ->setContextSerializer(new ContextSerializer);
+
+    config([
+        'settings.hash_algorithm' => 'xxh128',
+    ]);
+});
+
+it('generates a hash of a key', function () {
+    // N; is for a serialized null context object
+    expect($this->keyGenerator->generate('my-key'))->toBe(hash('xxh128', 'my-keyN;'));
+});
+
+it('generates a hash of a key and context object', function () {
+    $context = new Context([
+        'id' => 123,
+    ]);
+
+    expect($this->keyGenerator->generate('my-key', $context))
+        ->toBe(hash('xxh128', 'my-key' . serialize($context)));
+});
+
+it('works with other context serializers', function () {
+    $this->keyGenerator->setContextSerializer(new DotNotationContextSerializer);
+
+    $context = new Context([
+        'id' => 123,
+        'bool-value' => false,
+    ]);
+
+    expect($this->keyGenerator->generate('my-key', $context))
+        ->toBe(hash('xxh128', 'my-keyid:123::bool-value:0'));
+});


### PR DESCRIPTION
Adds a new `HashKeyGenerator`, which serves as an alternative to the `Md5KeyGenerator`. By default, the generator uses the `xxh128` hashing algorithm, but that can changed easily by modifying the `hash_algorithm` config value.